### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requires root to read portage logs. Might even work with `sudo -u portage`.
 The second option should be more secure, or less likely to break something.
 
 # Demo Output
-Output of the monitor in action as of [commit f79077c](https://github.com/ncdulo/portop/commit/f79077c7a58e9779ff51143670dd488a75f8cbab). If that commit is no longer current, this output may not be current. I will keep updated between large revisions, otherwise this is just a general feel of the monitor.
+Output of the monitor in action as of [commit c6ca17b](https://github.com/Phate6660/portop/commit/c6ca17b58841cbb83523e29c642edbcfebeea46e). If that commit is no longer current, this output may not be current. I will keep updated between large revisions, otherwise this is just a general feel of the monitor.
 ```
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                                    gentoo                                                     ││                                                 System Status                                                 │

--- a/README.md
+++ b/README.md
@@ -11,38 +11,37 @@ The second option should be more secure, or less likely to break something.
 # Demo Output
 Output of the monitor in action as of [commit f79077c](https://github.com/ncdulo/portop/commit/f79077c7a58e9779ff51143670dd488a75f8cbab). If that commit is no longer current, this output may not be current. I will keep updated between large revisions, otherwise this is just a general feel of the monitor.
 ```
-┌────────────────────────────────────────────────────────┐┌────────────────────────────────────────────────────────┐
-│                         mercury                        ││                 title information here                 │
-├────────────────────────────────────────────────────────┤├────────────────────────────────────────────────────────┤
-│                     Portage Status                     ││                    Core Frequencies                    │
-├────────────────────────────────────────────────────────┤├────────────────────────────────────────────────────────┤
-│                                                        ││                   cpu MHz		: 3492.815         │
-│              Currently merging 1 out of 1              ││                   cpu MHz		: 3371.200         │
-│                                                        ││                   cpu MHz		: 3346.858         │
-│                * x11-libs/libxcb-1.13.1                ││                   cpu MHz		: 3510.742         │
-│                                                        │└────────────────────────────────────────────────────────┘
-│         current merge time: 4 seconds.                 │┌────────────────────────────────────────────────────────┐
-│           ETA: less than a minute.                     ││                    emerge-fetch.log                    │
-└────────────────────────────────────────────────────────┘├────────────────────────────────────────────────────────┤
-┌────────────────────────────────────────────────────────┐│      0K .......... .......... .......... .......... ...│
-│                       emerge.log                       ││     50K .......... .......... .......... .......... ...│
-├────────────────────────────────────────────────────────┤│    100K .......... .......... .......... .......... ...│
-│ 1584810101:  *** exiting successfully.                 ││    150K .......... .......... .......... .......... ...│
-│ 1584810101:  *** terminating.                          ││    200K .......... .......... .......... .......... ...│
-│ 1584823780: Started emerge on: Mar 21, 2020 16:49:39   ││    250K .......... .......... .......... .......... ...│
-│ 1584823780:  *** emerge --oneshot --tree --ask --jobs=2│└────────────────────────────────────────────────────────┘
-│ 1584823800:  >>> emerge (1 of 1) x11-libs/libxcb-1.13.1│
-│ 1584823800:  === (1 of 1) Cleaning (x11-libs/libxcb-1.1│
-│ 1584823800:  === (1 of 1) Compiling/Merging (x11-libs/l│
-└────────────────────────────────────────────────────────┘
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                    gentoo                                                     ││                                                 System Status                                                 │
+├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                Portage Status                                                 ││                                          Load average:0.58 0.42 0.38                                          │
+├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                 !!! Error: no working merge found.                                            ││                                              cpu MHz : 2675.633                                               │
+│                  (the -c option only works if there is an ongoing compilation, see manpage)                   ││                                              cpu MHz : 2397.806                                               │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘│                                              cpu MHz : 3129.755                                               │
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐│                                              cpu MHz : 2440.836                                               │
+│                                                  emerge.log                                                   │├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤│                                               Core 0: +100.4°                                                 │
+│ 1584815435:  >>> AUTOCLEAN: dev-vcs/gh-bin:0                                                                  ││                                                Core 1: +98.6°                                                 │
+│ 1584815437:  === (1 of 1) Updating world file (dev-vcs/gh-bin-0.6.2)                                          ││                                               Core 2: +114.8°                                                 │
+│ 1584815437:  === (1 of 1) Post-Build Cleaning (dev-vcs/gh-bin-0.6.2::/var/db/repos/p6nc/dev-vcs/gh-bin/gh-bin-││                                               Core 3: +102.2°                                                 │
+│ 1584815437:  ::: completed emerge (1 of 1) dev-vcs/gh-bin-0.6.2 to /                                          │└───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+│ 1584815437:  *** Finished. Cleaning up...                                                                     │┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ 1584815437:  *** exiting successfully.                                                                        ││                                               emerge-fetch.log                                                │
+│ 1584815437:  *** terminating.                                                                                 │├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘│                                                                                                               │
+                                                                                                                 │      0K ........                                              100% 57.6M=0s                                   │
+                                                                                                                 │                                                                                                               │
+                                                                                                                 │ 2020-03-20 21:34:47 (57.6 MB/s) - ‘/var/cache/distfiles/LWP-UserAgent-Cached-0.06.tar.gz.__download__’ save   │
+                                                                                                                 │                                                                                                               │
+                                                                                                                 │  * LWP-UserAgent-Cached-0.06.tar.gz BLAKE2B SHA512 size ;-) ...          [ ok ]                               │
+                                                                                                                 │  * 0.0.2.tar.gz size ;-) ...                                             [ ok ]                               │
+                                                                                                                 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 # Usage & Requirements
 No special setup required for this one. However, a Bash-compatible shell, `genlop`, `lm_sensors`, and of course `emerge` are required to exist on the system. This will only work on Linux systems with the Portage package manager installed. Geared towards Gentoo Linux, it may work Bedrock, Mandrake, or derivatives.
 
-To simply run the monitor, after cloning into the repo:
-```bash
-# Run as portage
-sudo -u portage ./portop
-# Run as root
-sudo ./portop
-```
+Clone the repo: `git clone --recurse https://github.com/ncdulo/portop`<br>
+cd into it: `cd portop`<br>
+Run as root: `sudo ./portop`<br>
+Or if you'd rather run it as portage: `sudo -u portage ./portop`<br>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The second option should be more secure, or less likely to break something.
 # Demo Output
 Output of the monitor in action as of [commit f79077c](https://github.com/ncdulo/portop/commit/f79077c7a58e9779ff51143670dd488a75f8cbab). If that commit is no longer current, this output may not be current. I will keep updated between large revisions, otherwise this is just a general feel of the monitor.
 ```
-───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                                    gentoo                                                     ││                                                 System Status                                                 │
 ├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤├───────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                Portage Status                                                 ││                                          Load average:0.58 0.42 0.38                                          │


### PR DESCRIPTION
Include instructions to recursively clone the repo, as it `portop` will fail to run if you don't clone the submodule.

Include an updated demo.

Also, you can ignore the first commit. That does nothing, it was just me syncing my fork to the repo. The second commit is where the README was changed.

Edit: The updated demo looks bad in the diff, but it looks surprisingly good. Take a look at my fork's README to see how it actually looks.